### PR TITLE
Add CMake build and CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@
 x64/
 Debug/
 Release/
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.10)
+project(MFTIndexer LANGUAGES CXX)
+
+add_library(MFTIndexer SHARED
+    MFTIndexer/MFTIndexer.cpp
+)
+if (MINGW)
+    target_link_options(MFTIndexer PRIVATE -static -static-libstdc++ -static-libgcc)
+endif()
+
+target_include_directories(MFTIndexer PUBLIC
+    ${PROJECT_SOURCE_DIR}/MFTIndexer
+)
+
+add_executable(MFTIndexerCli
+    MFTIndexer/main.cpp
+)
+
+target_link_libraries(MFTIndexerCli PRIVATE MFTIndexer)
+if (MINGW)
+    target_link_options(MFTIndexerCli PRIVATE -municode -static -static-libstdc++ -static-libgcc)
+endif()
+
+set_target_properties(MFTIndexer PROPERTIES
+    OUTPUT_NAME "MFTIndexer"
+)
+
+set_target_properties(MFTIndexerCli PROPERTIES
+    OUTPUT_NAME "MFTIndexer"
+)
+

--- a/MFTIndexer/MFTIndexer.h
+++ b/MFTIndexer/MFTIndexer.h
@@ -1,0 +1,25 @@
+#ifndef MFTINDEXER_H
+#define MFTINDEXER_H
+
+#ifdef _WIN32
+#  include <windows.h>
+#  ifdef MFTINDEXER_EXPORTS
+#    define MFTINDEXER_API __declspec(dllexport)
+#  else
+#    define MFTINDEXER_API __declspec(dllimport)
+#  endif
+#else
+#  define MFTINDEXER_API
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+MFTINDEXER_API bool ExportMFTToJson(const wchar_t* volumePath, const wchar_t* outputPath);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MFTINDEXER_H

--- a/MFTIndexer/main.cpp
+++ b/MFTIndexer/main.cpp
@@ -1,0 +1,26 @@
+#include "MFTIndexer.h"
+#include <iostream>
+#include <string>
+#include <cwchar>
+
+int wmain(int argc, wchar_t* argv[])
+{
+    const wchar_t* volume = L"\\\\.\\C:";
+    const wchar_t* output = L"mft.json";
+
+    for (int i = 1; i < argc; ++i) {
+        if (wcscmp(argv[i], L"--volume") == 0 && i + 1 < argc) {
+            volume = argv[++i];
+        } else if (wcscmp(argv[i], L"--export") == 0 && i + 1 < argc) {
+            output = argv[++i];
+        }
+    }
+
+    if (!ExportMFTToJson(volume, output)) {
+        std::wcerr << L"Failed to export MFT" << std::endl;
+        return 1;
+    }
+
+    std::wcout << L"Exported to " << output << std::endl;
+    return 0;
+}

--- a/README.md
+++ b/README.md
@@ -29,13 +29,27 @@ Unlike traditional indexing, it avoids recursive directory scanning, resulting i
 
 ## Usage
 
+### Building
+
+This project targets Windows and can be compiled with Visual Studio or with
+[CMake](https://cmake.org/) using a MinGW toolchain.
+
+```bash
+# Example using mingw-w64 on Linux
+cmake -B build -DCMAKE_TOOLCHAIN_FILE=<path-to-mingw-toolchain.cmake>
+cmake --build build --config Release
+```
+
+The resulting `MFTIndexer.dll` library and `MFTIndexer.exe` CLI are produced in
+the build directory.
+
 ### As an executable
 
 ```bash
 MFTIndexer.exe --export output.json
 ```
 
-> Exports a full list of file paths to `output.json`.
+Exports a full list of file paths to `output.json`.
 
 ### As a DLL
 

--- a/mingw-toolchain.cmake
+++ b/mingw-toolchain.cmake
@@ -1,0 +1,4 @@
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_C_COMPILER x86_64-w64-mingw32-gcc)
+set(CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++)
+set(CMAKE_RC_COMPILER x86_64-w64-mingw32-windres)


### PR DESCRIPTION
## Summary
- add MFTIndexer.h for external integration
- provide a simple CLI in `main.cpp`
- add CMake build script and toolchain example
- update README with build instructions
- ignore build artifacts

## Testing
- `cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=mingw-toolchain.cmake`
- `cmake --build build --config Release`


------
https://chatgpt.com/codex/tasks/task_e_68530d5d4570832fb0809e391b82a3f1