### PR TITLE
Improve CLI options and export API

### DIFF
--- a/MFTIndexer/MFTIndexer.h
+++ b/MFTIndexer/MFTIndexer.h
@@ -17,6 +17,8 @@ extern "C" {
 #endif
 
 MFTINDEXER_API bool ExportMFTToJson(const wchar_t* volumePath, const wchar_t* outputPath);
+typedef void(__stdcall *MFTPathCallback)(const wchar_t* path);
+MFTINDEXER_API bool ExportMFTToMemory(const wchar_t* volumePath, MFTPathCallback callback);
 
 #ifdef __cplusplus
 }

--- a/MFTIndexerCLI/MFTIndexerCLI.csproj
+++ b/MFTIndexerCLI/MFTIndexerCLI.csproj
@@ -1,10 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
 </Project>

--- a/MFTIndexerCLI/Program.cs
+++ b/MFTIndexerCLI/Program.cs
@@ -1,35 +1,101 @@
-﻿using System;
+using System;
+using System.IO;
 using System.Runtime.InteropServices;
+using System.Security.Principal;
 
-class Program
+internal class Program
 {
     [DllImport("MFTIndexer.dll", CharSet = CharSet.Unicode)]
     public static extern bool ExportMFTToJson(string volumePath, string outputFile);
 
-    static void Main(string[] args)
+    private static bool IsAdministrator()
     {
-        Console.WriteLine("=== MFTIndexerCLI ===");
+        using WindowsIdentity identity = WindowsIdentity.GetCurrent();
+        WindowsPrincipal principal = new(identity);
+        return principal.IsInRole(WindowsBuiltInRole.Administrator);
+    }
 
-        if (args.Length < 1)
+    private static void PrintUsage()
+    {
+        Console.WriteLine("Usage: MFTIndexerCLI [-d DRIVE] [-o OUTPUT] [--silent]");
+        Console.WriteLine("  -d, --drive   Drive letter to index (default: C)");
+        Console.WriteLine("  -o, --output  Path to output json file (default: output.json)");
+        Console.WriteLine("  -s, --silent  Suppress console output");
+    }
+
+    static int Main(string[] args)
+    {
+        string drive = "C";
+        string output = "output.json";
+        bool silent = false;
+
+        for (int i = 0; i < args.Length; i++)
         {
-            Console.WriteLine("Argument manquant : lettre du lecteur (ex: C)");
-            return;
+            switch (args[i])
+            {
+                case "-d":
+                case "--drive":
+                    if (i + 1 >= args.Length)
+                    {
+                        Console.Error.WriteLine("Missing value for --drive");
+                        return 1;
+                    }
+                    drive = args[++i];
+                    break;
+                case "-o":
+                case "--output":
+                    if (i + 1 >= args.Length)
+                    {
+                        Console.Error.WriteLine("Missing value for --output");
+                        return 1;
+                    }
+                    output = args[++i];
+                    break;
+                case "-s":
+                case "--silent":
+                    silent = true;
+                    break;
+                case "-h":
+                case "--help":
+                    PrintUsage();
+                    return 0;
+                default:
+                    Console.Error.WriteLine($"Unknown argument: {args[i]}");
+                    PrintUsage();
+                    return 1;
+            }
         }
 
-        string driveLetter = args[0];
-        string volumePath = driveLetter + ":\\";
-        string outputFile = "output.json";
-
-        Console.WriteLine($"Lancement de l'export pour {volumePath}...");
-        bool success = ExportMFTToJson(volumePath, outputFile);
-
-        if (success)
+        if (!Directory.Exists($"{drive}:\\"))
         {
-            Console.WriteLine($"MFT exportée dans {outputFile}");
+            if (!silent)
+                Console.Error.WriteLine($"Invalid drive letter: {drive}");
+            return 1;
         }
-        else
+
+        if (!IsAdministrator())
         {
-            Console.WriteLine($"Échec lors de l'export !");
+            if (!silent)
+                Console.Error.WriteLine("Administrator privileges are required.");
+            return 1;
         }
+
+        string volumePath = $"\\\\.\\{drive.TrimEnd(':')}:";
+
+        if (!silent)
+            Console.WriteLine($"Exporting {volumePath} to {output}...");
+
+        bool success = ExportMFTToJson(volumePath, output);
+
+        if (!silent)
+        {
+            if (success)
+                Console.WriteLine($"MFT exported to {output}");
+            else
+                Console.WriteLine("Export failed");
+        }
+
+        return success ? 0 : 1;
     }
 }
+

--- a/README.md
+++ b/README.md
@@ -46,16 +46,17 @@ the build directory.
 ### As an executable
 
 ```bash
-MFTIndexer.exe --export output.json
+MFTIndexer.exe -d C -o paths.json
 ```
 
-Exports a full list of file paths to `output.json`.
+Exports all file paths from drive `C:` to `paths.json`. Use `-s` for silent mode.
 
 ### As a DLL
 
 ```cpp
 // Exported from the DLL
-void ExportToJson(const wchar_t* outputPath);
+bool ExportMFTToJson(const wchar_t* volumePath, const wchar_t* outputPath);
+bool ExportMFTToMemory(const wchar_t* volumePath, MFTPathCallback cb);
 ```
 
 > Ideal for integration with C++, C#, Rust or any language supporting native interop.
@@ -66,7 +67,7 @@ void ExportToJson(const wchar_t* outputPath);
 
 ```csharp
 [DllImport("MFTIndexer.dll", CharSet = CharSet.Unicode)]
-public static extern void ExportToJson(string outputPath);
+public static extern bool ExportMFTToJson(string volumePath, string outputPath);
 ```
 
 ---

--- a/build_and_run.bat
+++ b/build_and_run.bat
@@ -10,7 +10,7 @@ if "%DRIVE%"=="" (
 
 set ROOT=%~dp0
 set DLL_SRC=%ROOT%MFTIndexer\x64\Release\MFTIndexer.dll
-set DLL_DEST=%ROOT%MFTIndexerCLI\bin\Release\net9.0\MFTIndexer.dll
+set DLL_DEST=%ROOT%MFTIndexerCLI\bin\Release\net8.0\MFTIndexer.dll
 set CLI_DIR=%ROOT%MFTIndexerCLI
 
 :: --- Build .NET ---
@@ -32,7 +32,7 @@ if not exist "%DLL_DEST%" (
 
 :: --- Exécution ---
 echo [3/4] Exécution depuis le bon dossier...
-cd /d "%CLI_DIR%\bin\Release\net9.0"
+cd /d "%CLI_DIR%\bin\Release\net8.0"
 echo [4/4] Lancement de MFTIndexerCLI.exe sur %DRIVE%:
 MFTIndexerCLI.exe %DRIVE%
 


### PR DESCRIPTION
## Summary
- provide configurable and silent CLI
- compile for .NET 8 instead of 9
- output drive letters in JSON
- expose new `ExportMFTToMemory` API
- document usage and update build script

## Testing
- `dotnet build MFTIndexerCLI/MFTIndexerCLI.csproj -c Release`
- `cmake -B build -DCMAKE_TOOLCHAIN_FILE=mingw-toolchain.cmake`
- `cmake --build build --config Release`


------
https://chatgpt.com/codex/tasks/task_e_685432172678832f80efd22e457f4d94