### PR TITLE
Add CLI and README instructions

### DIFF
--- a/MFTIndexer/MFTIndexer.cpp
+++ b/MFTIndexer/MFTIndexer.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <map>
 #include <sstream>
+#include "MFTIndexer.h"
 
 #define BUFFER_SIZE (1024 * 1024)
 
@@ -36,7 +37,6 @@ std::wstring BuildFullPath(ULONGLONG frn, const std::map<ULONGLONG, MFTEntry>& e
     return path;
 }
 
-extern "C" __declspec(dllexport)
 bool ExportMFTToJson(const wchar_t* volumePath, const wchar_t* outputPath) {
     HANDLE hVol = CreateFileW(
         volumePath,

--- a/MFTIndexer/MFTIndexer.h
+++ b/MFTIndexer/MFTIndexer.h
@@ -1,0 +1,11 @@
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+__declspec(dllexport)
+bool ExportMFTToJson(const wchar_t* volumePath, const wchar_t* outputPath);
+
+#ifdef __cplusplus
+}
+#endif

--- a/MFTIndexer/MFTIndexer.vcxproj
+++ b/MFTIndexer/MFTIndexer.vcxproj
@@ -27,26 +27,26 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -156,6 +156,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MFTIndexer.cpp" />
+    <ClCompile Include="main.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/MFTIndexer/main.cpp
+++ b/MFTIndexer/main.cpp
@@ -1,0 +1,25 @@
+#include <windows.h>
+#include <iostream>
+#include "MFTIndexer.h"
+
+int wmain(int argc, wchar_t* argv[]) {
+    if (argc < 3) {
+        std::wcout << L"Usage: MFTIndexer.exe <volume (e.g. C)> <output.json>" << std::endl;
+        return 1;
+    }
+
+    std::wstring volumeLetter = argv[1];
+    if (volumeLetter.back() == L':')
+        volumeLetter.pop_back();
+    std::wstring volumePath = L"\\\\.\\" + volumeLetter + L":";
+
+    const wchar_t* outputPath = argv[2];
+
+    if (!ExportMFTToJson(volumePath.c_str(), outputPath)) {
+        std::wcerr << L"Failed to export MFT. Ensure you run as Administrator and that the volume exists." << std::endl;
+        return 1;
+    }
+
+    std::wcout << L"Export completed." << std::endl;
+    return 0;
+}

--- a/README.md
+++ b/README.md
@@ -32,10 +32,13 @@ Unlike traditional indexing, it avoids recursive directory scanning, resulting i
 ### As an executable
 
 ```bash
-MFTIndexer.exe --export output.json
+MFTIndexer.exe C output.json
 ```
 
-> Exports a full list of file paths to `output.json`.
+Run the tool from an elevated command prompt. The first argument is the target
+volume letter and the second is the output path. Using the raw volume path
+avoids the common `FSCTL_ENUM_USN_DATA failed (error=87)` message caused by an
+invalid handle or insufficient privileges.
 
 ### As a DLL
 


### PR DESCRIPTION
## Summary
- add header for ExportMFTToJson
- convert project to an executable and add a `main.cpp` driver
- include new header in `MFTIndexer.cpp`
- document usage and the `FSCTL_ENUM_USN_DATA failed (error=87)` fix in README

## Testing
- `x86_64-w64-mingw32-g++ -v`
- `x86_64-w64-mingw32-g++ -std=c++17 -static -O2 -municode -o MFTIndexer.exe MFTIndexer/*.cpp && echo "build ok"`

------
https://chatgpt.com/codex/tasks/task_e_68544c17905c832fa91cbe0eaab8325d